### PR TITLE
Update dependency name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Cargo.toml:
 
 ```
 [dependencies]
-zebedee_rust = "0.3.6"
+zebedee-rust = "0.3.6"
 ```
 
 ## Example usage of some of the functions:


### PR DESCRIPTION
The package name is incorrect in the readme. It should be `zebedee-rust`, with a dash, not an underscore