### PR TITLE
Refactor FetchRefresh/FetchTokenBody & code improvements to avoid allocations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -394,7 +394,10 @@ impl ZebedeeClient {
         self.parse_response(resp).await
     }
 
-    pub async fn create_auth_url(&self, challenge: String) -> Result<String> {
+    pub async fn create_auth_url<T>(&self, challenge: T) -> Result<String>
+    where
+        T: AsRef<str>,
+    {
         let url = format!("{}/v1/oauth2/authorize", &self.domain);
 
         let auth_url = self
@@ -405,7 +408,7 @@ impl ZebedeeClient {
             .query(&[("response_type", "code")])
             .query(&[("redirect_uri", &self.oauth.redirect_uri)])
             .query(&[("code_challenge_method", "S256")])
-            .query(&[("code_challenge", challenge)])
+            .query(&[("code_challenge", challenge.as_ref())])
             .query(&[("scope", &self.oauth.scope)])
             .query(&[("state", &self.oauth.state)])
             .build()
@@ -461,7 +464,10 @@ impl ZebedeeClient {
 
     /// You can use this API endpoint to fetch information about a given ZBD User, granted you can pass the provided accessToken.
 
-    pub async fn fetch_user_data(&self, token: String) -> Result<StdResp<ZBDUserData>> {
+    pub async fn fetch_user_data<T>(&self, token: T) -> Result<StdResp<ZBDUserData>>
+    where
+        T: AsRef<str>,
+    {
         //let mut token_header_string: String = "Bearer ".to_owned();
         //token_header_string.push_str(&bearer_token);
 
@@ -469,7 +475,7 @@ impl ZebedeeClient {
 
         let resp = self
             .add_headers(self.reqw_cli.get(&url))
-            .header("usertoken", token)
+            .header("usertoken", token.as_ref())
             .send()
             .await?;
 
@@ -477,10 +483,10 @@ impl ZebedeeClient {
     }
 
     /// You can use this API endpoint to fetch information about a given ZBD User's Wallet, granted you can pass the provided accessToken.
-    pub async fn fetch_user_wallet_data(
-        &self,
-        token: String,
-    ) -> Result<StdResp<ZBDUserWalletData>> {
+    pub async fn fetch_user_wallet_data<T>(&self, token: T) -> Result<StdResp<ZBDUserWalletData>>
+    where
+        T: AsRef<str>,
+    {
         //let mut token_header_string: String = "Bearer ".to_owned();
         //token_header_string.push_str(&bearer_token);
 
@@ -488,7 +494,7 @@ impl ZebedeeClient {
 
         let resp = self
             .add_headers(self.reqw_cli.get(&url))
-            .header("usertoken", token)
+            .header("usertoken", token.as_ref())
             .send()
             .await?;
 

--- a/src/login_with_zbd/tests.rs
+++ b/src/login_with_zbd/tests.rs
@@ -1,11 +1,10 @@
-use super::*;
 use crate::ZebedeeClient;
 use crate::PKCE;
 use std::env;
 
 #[tokio::test]
 async fn test_create_challenge_from_string() {
-    let c = PKCE::new_from_string(String::from("hellomynameiswhat"));
+    let c = PKCE::from("hellomynameiswhat");
 
     assert_eq!(
         c.challenge,
@@ -42,7 +41,7 @@ async fn test_create_oauth_auth_url() {
         )
         .build();
 
-    let c = PKCE::new_from_string(String::from("hellomynameiswhat"));
+    let c = PKCE::from("hellomynameiswhat");
     let r = zebedee_client.create_auth_url(c.challenge.clone());
 
     assert!(r.await.is_ok());
@@ -70,10 +69,9 @@ async fn test_fetch_token() {
         )
         .build();
 
-    let c = PKCE::new_from_string(String::from("hellomynameiswhat"));
-    let fake_code = String::from("xxx11xx1-xxxx-xxxx-xxx1-1xx11xx111xx");
-    let fetchbody = FetchTokenBody::new(&zebedee_client, fake_code, c.verifier);
-    let r = zebedee_client.fetch_token(&fetchbody);
+    let c = PKCE::from("hellomynameiswhat");
+    let fake_code = "xxx11xx1-xxxx-xxxx-xxx1-1xx11xx111xx";
+    let r = zebedee_client.fetch_token(fake_code, c.verifier);
     //let mut i = String::from("");
     let i = match r.await {
         Err(e) => e.to_string(),
@@ -105,9 +103,8 @@ async fn test_refresh_token() {
         )
         .build();
 
-    let fake_refresh_token = String::from("xxx11xx1-xxxx-xxxx-xxx1-1xx11xx111xx");
-    let fetchbody = FetchRefresh::new(zebedee_client.clone(), fake_refresh_token);
-    let r = zebedee_client.refresh_token(fetchbody);
+    let fake_refresh_token = "xxx11xx1-xxxx-xxxx-xxx1-1xx11xx111xx";
+    let r = zebedee_client.refresh_token(fake_refresh_token);
     let i = match r.await {
         Err(e) => e.to_string(),
         Ok(_) => "this worked but how?".to_string(),

--- a/src/login_with_zbd/tests.rs
+++ b/src/login_with_zbd/tests.rs
@@ -73,7 +73,7 @@ async fn test_fetch_token() {
     let c = PKCE::new_from_string(String::from("hellomynameiswhat"));
     let fake_code = String::from("xxx11xx1-xxxx-xxxx-xxx1-1xx11xx111xx");
     let fetchbody = FetchTokenBody::new(&zebedee_client, fake_code, c.verifier);
-    let r = zebedee_client.fetch_token(fetchbody);
+    let r = zebedee_client.fetch_token(&fetchbody);
     //let mut i = String::from("");
     let i = match r.await {
         Err(e) => e.to_string(),

--- a/src/login_with_zbd/tests.rs
+++ b/src/login_with_zbd/tests.rs
@@ -42,7 +42,7 @@ async fn test_create_oauth_auth_url() {
         .build();
 
     let c = PKCE::from("hellomynameiswhat");
-    let r = zebedee_client.create_auth_url(c.challenge.clone());
+    let r = zebedee_client.create_auth_url(&c.challenge);
 
     assert!(r.await.is_ok());
 }

--- a/src/login_with_zbd/types.rs
+++ b/src/login_with_zbd/types.rs
@@ -3,10 +3,6 @@ use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use validator::Validate;
 
-// pub type CreateWithdrawalResponse = StdResp<Option<WithdrawalRequestsData>>;
-// pub type FetchWithdrawalsResponse = StdResp<Option<Vec<WithdrawalRequestsData>>>;
-// pub type FetchOneWithdrawalResponse = StdResp<Option<WithdrawalRequestsData>>;
-
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct FetchPostRes {
     pub access_token: String,
@@ -33,30 +29,34 @@ impl<'a> AuthURL<'a> {
 
 /// Use this struct to create a well crafted json body for token management with ZBD Oauth
 #[derive(Serialize, Clone, Validate, Deserialize, Debug)]
-pub struct FetchTokenBody {
+pub struct FetchTokenBody<'a> {
     #[validate(length(equal = 36))]
-    pub client_id: String,
+    pub client_id: Cow<'a, str>,
     #[validate(length(equal = 36))]
-    pub client_secret: String,
+    pub client_secret: Cow<'a, str>,
     #[validate(length(equal = 36))]
-    pub code: String,
+    pub code: Cow<'a, str>,
     #[validate(length(equal = 43))]
-    pub code_verifier: String,
+    pub code_verifier: Cow<'a, str>,
     #[validate(length(min = 1))]
-    pub grant_type: String,
+    pub grant_type: Cow<'a, str>,
     #[validate(url)]
-    pub redirect_uri: String,
+    pub redirect_uri: Cow<'a, str>,
 }
 
-impl FetchTokenBody {
-    pub fn new(zc: &ZebedeeClient, code: String, code_verifier: String) -> Self {
+impl<'a> FetchTokenBody<'a> {
+    pub fn new<A, B>(zc: &'a ZebedeeClient, code: A, code_verifier: B) -> Self
+    where
+        A: Into<Cow<'a, str>>,
+        B: Into<Cow<'a, str>>,
+    {
         FetchTokenBody {
-            client_id: zc.oauth.client_id.clone(),
-            client_secret: zc.oauth.secret.clone(),
-            code,
-            code_verifier,
-            grant_type: String::from("authorization_code"),
-            redirect_uri: zc.oauth.redirect_uri.clone(),
+            client_id: zc.oauth.client_id.as_str().into(),
+            client_secret: zc.oauth.secret.as_str().into(),
+            code: code.into(),
+            code_verifier: code_verifier.into(),
+            grant_type: "authorization_code".into(),
+            redirect_uri: zc.oauth.redirect_uri.as_str().into(),
         }
     }
 }

--- a/src/login_with_zbd/types.rs
+++ b/src/login_with_zbd/types.rs
@@ -94,27 +94,30 @@ pub struct FetchAccessTokenRes {
 
 /// Use this struct to create a well crafted json body for token refreshes with ZBD Oauth
 #[derive(Serialize, Validate, Deserialize, Debug)]
-pub struct FetchRefresh {
+pub struct FetchRefresh<'a> {
     #[validate(length(equal = 36))]
-    pub client_id: String,
+    pub client_id: Cow<'a, str>,
     #[validate(length(equal = 36))]
-    pub client_secret: String,
+    pub client_secret: Cow<'a, str>,
     #[validate(length(equal = 36))]
-    pub refresh_token: String,
+    pub refresh_token: Cow<'a, str>,
     #[validate(length(min = 1))]
-    pub grant_type: String,
+    pub grant_type: Cow<'a, str>,
     #[validate(url)]
-    pub redirect_uri: String,
+    pub redirect_uri: Cow<'a, str>,
 }
 
-impl FetchRefresh {
-    pub fn new(zc: ZebedeeClient, refresh_token: String) -> Self {
+impl<'a> FetchRefresh<'a> {
+    pub fn new<T>(zc: &'a ZebedeeClient, refresh_token: T) -> Self
+    where
+        T: Into<Cow<'a, str>>,
+    {
         FetchRefresh {
-            client_id: zc.oauth.client_id,
-            client_secret: zc.oauth.secret,
-            grant_type: String::from("refresh_token"),
-            redirect_uri: zc.oauth.redirect_uri,
-            refresh_token,
+            client_id: zc.oauth.client_id.as_str().into(),
+            client_secret: zc.oauth.secret.as_str().into(),
+            grant_type: "refresh_token".into(),
+            redirect_uri: zc.oauth.redirect_uri.as_str().into(),
+            refresh_token: refresh_token.into(),
         }
     }
 }


### PR DESCRIPTION
- use references instead of owned values to avoid allocations in functions signatures & `FetchRefresh`/`FetchTokenBody` structs
- refactor ZebedeeClient `refresh_token` & `fetch_token` functions to hide some complexity from client
- Added `From` impl `PKCE` when creating a new instance from a string slice