### PR TITLE
add method to validate ln address format

### DIFF
--- a/src/ln_address/tests.rs
+++ b/src/ln_address/tests.rs
@@ -60,3 +60,12 @@ async fn test_validate_ln_address() {
         .success;
     assert!(r);
 }
+
+#[tokio::test]
+async fn test_validate_address_format() {
+    let ln_address = LnAddress {
+        address: "andre@zbd.gg".to_string(),
+    };
+
+    assert_eq!(ln_address.validate(), Ok(()));
+}

--- a/src/ln_address/types.rs
+++ b/src/ln_address/types.rs
@@ -1,4 +1,4 @@
-use crate::StdResp;
+use crate::{errors::ErrorMsg, StdResp};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -15,10 +15,12 @@ pub struct LnAddress {
 }
 
 impl LnAddress {
-    pub fn new(address: String) -> Result<Self, ValidationErrors> {
-        let address_format = LnAddress { address };
-        address_format.validate()?;
-        Ok(address_format)
+    pub fn new(address: String) -> Result<Self, ErrorMsg> {
+        let lightning_address = LnAddress { address };
+        lightning_address.validate().map_err(|e| {
+            ErrorMsg::BadLnAddress(lightning_address.address.clone(), e.to_string())
+        })?;
+        Ok(lightning_address)
     }
 }
 

--- a/src/ln_address/types.rs
+++ b/src/ln_address/types.rs
@@ -1,8 +1,8 @@
-use crate::{errors::ErrorMsg, StdResp};
+use crate::StdResp;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use validator::Validate;
+use validator::{Validate, ValidationErrors};
 
 pub type PayLnAddressResponse = StdResp<Option<LnSendPaymentData>>;
 pub type FetchLnChargeResponse = StdResp<Option<LnFetchChargeData>>;
@@ -15,12 +15,8 @@ pub struct LnAddress {
 }
 
 impl LnAddress {
-    pub fn new(address: String) -> Result<Self, ErrorMsg> {
-        let lightning_address = LnAddress { address };
-        lightning_address.validate().map_err(|e| {
-            ErrorMsg::BadLnAddress(lightning_address.address.clone(), e.to_string())
-        })?;
-        Ok(lightning_address)
+    pub fn validate(&self) -> Result<(), ValidationErrors> {
+        Validate::validate(&self)
     }
 }
 

--- a/src/ln_address/types.rs
+++ b/src/ln_address/types.rs
@@ -15,6 +15,8 @@ pub struct LnAddress {
 }
 
 impl LnAddress {
+    /// Verifies that the given lightning address is in a valid email format.
+    /// Returns `Ok(())` if the format is valid, and `Err(ValidationErrors)` otherwise.
     pub fn validate(&self) -> Result<(), ValidationErrors> {
         Validate::validate(&self)
     }

--- a/src/ln_address/types.rs
+++ b/src/ln_address/types.rs
@@ -14,6 +14,14 @@ pub struct LnAddress {
     pub address: String,
 }
 
+impl LnAddress {
+    pub fn new(address: String) -> Result<Self, ValidationErrors> {
+        let address_format = LnAddress { address };
+        address_format.validate()?;
+        Ok(address_format)
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LnPayerData {
     pub name: HashMap<String, bool>,


### PR DESCRIPTION
When using `.validate()` to validate an email(ln) address format, i get the error below. 

Adding the `validator` crate locally fixes this, but we can use a method instead  to check if it is valid without having to add an aditional crate. 

```
error[E0599]: no method named `validate` found for struct `LnAddress` in the current scope
   --> src/player.rs:121:56
    |
121 | ...                   let valid = ln_address.validate();
    |                                              ^^^^^^^^ method not found in `LnAddress`
    |
   ::: /Users/stu/.cargo/registry/src/index.crates.io-6f17d22bba15001f/validator-0.16.1/src/traits.rs:194:8
    |
194 |     fn validate(&self) -> Result<(), ValidationErrors>;
    |        -------- the method is available for `LnAddress` here
    |
    = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
    |
1   + use validator::traits::Validate;
```