### PR TITLE
implement Pay to Email

### DIFF
--- a/src/custom_deserializer.rs
+++ b/src/custom_deserializer.rs
@@ -1,0 +1,13 @@
+use serde::{Deserialize, Deserializer};
+use std::{fmt::Display, str::FromStr};
+
+pub fn deserialize_from_string<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: FromStr + serde::Deserialize<'de>,
+    <T as FromStr>::Err: Display,
+{
+    String::deserialize(deserializer)?
+        .parse::<T>()
+        .map_err(serde::de::Error::custom)
+}

--- a/src/email/mod.rs
+++ b/src/email/mod.rs
@@ -1,0 +1,4 @@
+mod types;
+pub use types::*;
+#[cfg(test)]
+mod tests;

--- a/src/email/tests.rs
+++ b/src/email/tests.rs
@@ -1,0 +1,36 @@
+use crate::ZebedeeClient;
+use std::env;
+
+use super::*;
+
+#[tokio::test]
+async fn test_pay_email() {
+    let apikey: String = env::var("ZBD_API_KEY").unwrap();
+    let zbdenv: String =
+        env::var("ZBD_ENV").unwrap_or_else(|_| String::from("https://api.zebedee.io"));
+    let email = env::var("EMAIL").unwrap();
+
+    let zebedee_client = ZebedeeClient::new().domain(zbdenv).apikey(apikey).build();
+
+    let email_payment_req = EmailPaymentReqest {
+        email,
+        amount: "3000".to_owned(),
+        comment: "from zbd rust 4".to_owned(),
+    };
+
+    let r = zebedee_client.pay_email(&email_payment_req).await.unwrap();
+    assert!(r.success);
+
+    match r.data {
+        EmailPaymentRes::ExistingZbdAccount(data) => {
+            assert!(r.message.map(|a| a.contains("Payment")).unwrap_or_default());
+            println!("Account exists");
+            println!("{data:#?}");
+        }
+        EmailPaymentRes::Voucher(data) => {
+            assert!(r.message.map(|a| a.contains("Voucher")).unwrap_or_default());
+            println!("Account does not exists");
+            println!("{data:#?}");
+        }
+    }
+}

--- a/src/email/types.rs
+++ b/src/email/types.rs
@@ -1,0 +1,43 @@
+use crate::{custom_deserializer::deserialize_from_string, StdResp, VoucherData};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+pub type EmailPaymentResponse = StdResp<EmailPaymentRes>;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum EmailPaymentRes {
+    /// Email is associated with an existing ZBD App account, then that user account will be credited the sats.
+    ExistingZbdAccount(EmailPaymentData),
+    /// Email not associated to a ZBD account, the sats will be issued to the email in the form of a valid ZBD Voucher that the recipient can redeem in the ZBD Mobile App.
+    Voucher(VoucherData),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmailPaymentData {
+    pub id: String,
+    // TODO: Convert from string to a proper Enum
+    pub status: String,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub amount: u64,
+    pub comment: String,
+    #[serde(rename = "receiverId")]
+    pub receiver_id: String,
+    #[serde(rename = "senderTxId")]
+    pub sender_tx_id: String,
+    #[serde(rename = "settledAt")]
+    pub settled_at: DateTime<Utc>,
+    #[serde(rename = "transactionId")]
+    pub transaction_id: String,
+}
+
+/// Send instant Bitcoin payments to any email
+#[derive(Debug, Serialize, Deserialize)]
+pub struct EmailPaymentReqest {
+    /// Recipient email to send payment to.
+    pub email: String,
+    /// Total amount of satoshis to send (in millisatoshis).
+    pub amount: String,
+    /// comment to be sent with the payment (max 150 characters).
+    pub comment: String,
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::fmt::Display;
 
 /// Zebedee Error
 #[derive(thiserror::Error, Debug)]
@@ -13,11 +14,14 @@ pub enum ZebedeeError {
     #[error("{0}")]
     Validate(#[from] validator::ValidationErrors),
     /// Error messages from Zebedee REST API
-    #[error("{0:?}")]
+    #[error("{0}")]
     Api(ApiError),
     /// Internal Error messages
-    #[error("{0:?}")]
+    #[error("{0}")]
     Msg(ErrorMsg),
+    /// Parseing errors
+    #[error("{0}")]
+    Parse(String),
 }
 
 /// Zebedee Rest API error message
@@ -53,5 +57,11 @@ impl From<ErrorMsg> for ZebedeeError {
 impl From<ApiError> for ZebedeeError {
     fn from(value: ApiError) -> Self {
         ZebedeeError::Api(value)
+    }
+}
+
+impl Display for ApiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.message.as_str())
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -19,9 +19,6 @@ pub enum ZebedeeError {
     /// Internal Error messages
     #[error("{0}")]
     Msg(ErrorMsg),
-    /// Parseing errors
-    #[error("{0}")]
-    Parse(String),
 }
 
 /// Zebedee Rest API error message

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,21 @@
 pub mod charges;
+mod custom_deserializer;
+pub mod email;
 pub mod errors;
 pub mod gamertag;
 pub mod internal_transfer;
 pub mod keysend;
 pub mod ln_address;
 pub mod login_with_zbd;
+mod models;
 pub mod payments;
 pub mod utilities;
+pub mod voucher;
 pub mod wallet;
 pub mod withdrawal_request;
 
 use charges::*;
+use email::*;
 use errors::*;
 use gamertag::*;
 use internal_transfer::*;
@@ -25,6 +30,7 @@ use serde_json::Value;
 use sha2::{Digest, Sha256};
 use utilities::*;
 use validator::Validate;
+use voucher::*;
 use wallet::*;
 use withdrawal_request::*;
 
@@ -392,6 +398,23 @@ impl ZebedeeClient {
             withdrawal_id.as_ref()
         );
         let resp = self.add_headers(self.reqw_cli.get(&url)).send().await?;
+        self.parse_response(resp).await
+    }
+
+    /// Send instant Bitcoin payments to any email.
+    pub async fn pay_email(
+        &self,
+        email_payment_request: &EmailPaymentReqest,
+    ) -> Result<EmailPaymentResponse> {
+        let url = format!("{}/v0/email/send-payment", &self.domain);
+
+        let resp = self
+            .add_headers(self.reqw_cli.post(&url))
+            .header("Content-Type", "application/json")
+            .json(&email_payment_request)
+            .send()
+            .await?;
+
         self.parse_response(resp).await
     }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,0 +1,9 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum UnitType {
+    #[serde(rename = "msats")]
+    Msats,
+    #[serde(rename = "sats")]
+    Sats,
+}

--- a/src/voucher/mod.rs
+++ b/src/voucher/mod.rs
@@ -1,0 +1,2 @@
+mod types;
+pub use types::*;

--- a/src/voucher/types.rs
+++ b/src/voucher/types.rs
@@ -1,0 +1,21 @@
+use crate::{custom_deserializer::deserialize_from_string, models::UnitType};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VoucherData {
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub amount: u64,
+    pub code: String,
+    #[serde(rename = "createdAt")]
+    pub created_at: DateTime<Utc>,
+    #[serde(rename = "createTransactionId")]
+    pub create_transaction_id: String,
+    pub description: String,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub fee: u64,
+    pub id: String,
+    pub unit: UnitType,
+    #[serde(rename = "walletId")]
+    pub wallet_id: String,
+}


### PR DESCRIPTION
- Implemented [Pay to Email](https://zbd.dev/api-reference/email/send)
-  implemented `Display` Trait for `ApiRes` struct & removed Debug Display on ` ZebedeeError`
- implemented a custom generic deserializer in order to convert in desired data types the response from api in struct fields
- implemented `UnitType` enum, In an such library it's always a good idea to divide into enums when possible the data to leverage the work for developer when using the crate
