### PR TITLE
refactor ZebedeeClient builder pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ use zebedee_rust::{charges::*, ZebedeeClient};
 #[tokio::main]
 async fn main() {
     let apikey: String = env::var("ZBD_API_KEY").unwrap();
-    let zebedee_client = ZebedeeClient::new().apikey(apikey).build();
+    let zebedee_client = ZebedeeClient::new(apikey);
 
     // Create a Bolt 11 Invoice for 5000 msat or 5 sat.
     let charge = Charge {
@@ -40,7 +40,7 @@ use zebedee_rust::{ln_address::*, ZebedeeClient};
 #[tokio::main]
 async fn main() {
     let apikey: String = env::var("ZBD_API_KEY").unwrap();
-    let zebedee_client = ZebedeeClient::new().apikey(apikey).build();
+    let zebedee_client = ZebedeeClient::new(apikey);
 
     // Create a Lightning payment
     let payment = LnPayment {
@@ -66,7 +66,7 @@ use zebedee_rust::{internal_transfer::*, ZebedeeClient};
 #[tokio::main]
 async fn main() {
     let apikey: String = env::var("ZBD_API_KEY").unwrap();
-    let zebedee_client = ZebedeeClient::new().apikey(apikey).build();
+    let zebedee_client = ZebedeeClient::new(apikey);
 
     // Send Internal Transfer
     let internal_transfer_payload = InternalTransfer {

--- a/src/charges/tests.rs
+++ b/src/charges/tests.rs
@@ -7,7 +7,7 @@ async fn test_create_charge() {
     let apikey: String = env::var("ZBD_API_KEY").unwrap();
     let zbdenv: String =
         env::var("ZBD_ENV").unwrap_or_else(|_| String::from("https://api.zebedee.io"));
-    let zebedee_client = ZebedeeClient::new().domain(zbdenv).apikey(apikey).build();
+    let zebedee_client = ZebedeeClient::new(apikey).domain(zbdenv);
     let charge = Charge {
         amount: String::from("1000"),
         ..Default::default()
@@ -22,7 +22,7 @@ async fn test_get_charges() {
     let apikey: String = env::var("ZBD_API_KEY").unwrap();
     let zbdenv: String =
         env::var("ZBD_ENV").unwrap_or_else(|_| String::from("https://api.zebedee.io"));
-    let zebedee_client = ZebedeeClient::new().domain(zbdenv).apikey(apikey).build();
+    let zebedee_client = ZebedeeClient::new(apikey).domain(zbdenv);
 
     let r = zebedee_client.get_charges().await.unwrap();
     assert!(r.success);
@@ -32,7 +32,7 @@ async fn test_get_charge() {
     let apikey: String = env::var("ZBD_API_KEY").unwrap();
     let zbdenv: String =
         env::var("ZBD_ENV").unwrap_or_else(|_| String::from("https://api.zebedee.io"));
-    let zebedee_client = ZebedeeClient::new().domain(zbdenv).apikey(apikey).build();
+    let zebedee_client = ZebedeeClient::new(apikey).domain(zbdenv);
 
     let charge = Charge {
         amount: String::from("1000"),

--- a/src/email/tests.rs
+++ b/src/email/tests.rs
@@ -10,7 +10,7 @@ async fn test_pay_email() {
         env::var("ZBD_ENV").unwrap_or_else(|_| String::from("https://api.zebedee.io"));
     let email = env::var("EMAIL").unwrap();
 
-    let zebedee_client = ZebedeeClient::new().domain(zbdenv).apikey(apikey).build();
+    let zebedee_client = ZebedeeClient::new(apikey).domain(zbdenv);
 
     let email_payment_req = EmailPaymentReqest {
         email,

--- a/src/gamertag/tests.rs
+++ b/src/gamertag/tests.rs
@@ -7,7 +7,7 @@ async fn test_pay_gamertag() {
     let apikey: String = env::var("ZBD_API_KEY").unwrap();
     let zbdenv: String =
         env::var("ZBD_ENV").unwrap_or_else(|_| String::from("https://api.zebedee.io"));
-    let zebedee_client = ZebedeeClient::new().domain(zbdenv).apikey(apikey).build();
+    let zebedee_client = ZebedeeClient::new(apikey).domain(zbdenv);
 
     let payment = GamertagPayment {
         gamertag: String::from("miketwenty1"),
@@ -24,7 +24,7 @@ async fn test_fetch_charge_from_gamertag() {
     let apikey: String = env::var("ZBD_API_KEY").unwrap();
     let zbdenv: String =
         env::var("ZBD_ENV").unwrap_or_else(|_| String::from("https://api.zebedee.io"));
-    let zebedee_client = ZebedeeClient::new().domain(zbdenv).apikey(apikey).build();
+    let zebedee_client = ZebedeeClient::new(apikey).domain(zbdenv);
 
     let payment = GamertagPayment {
         gamertag: String::from("miketwenty1"),
@@ -46,7 +46,7 @@ async fn test_get_gamertag_tx() {
     let apikey: String = env::var("ZBD_API_KEY").unwrap();
     let zbdenv: String =
         env::var("ZBD_ENV").unwrap_or_else(|_| String::from("https://api.zebedee.io"));
-    let zebedee_client = ZebedeeClient::new().domain(zbdenv).apikey(apikey).build();
+    let zebedee_client = ZebedeeClient::new(apikey).domain(zbdenv);
 
     let transaction_id = String::from("322294d5-c993-4eef-88a8-8c9de099e16b");
 
@@ -63,7 +63,7 @@ async fn test_get_userid_by_gamertag() {
     let apikey: String = env::var("ZBD_API_KEY").unwrap();
     let zbdenv: String =
         env::var("ZBD_ENV").unwrap_or_else(|_| String::from("https://api.zebedee.io"));
-    let zebedee_client = ZebedeeClient::new().domain(zbdenv).apikey(apikey).build();
+    let zebedee_client = ZebedeeClient::new(apikey).domain(zbdenv);
 
     let gamertag = String::from("miketwenty1");
 
@@ -80,7 +80,7 @@ async fn test_get_gamertag_by_userid() {
     let apikey: String = env::var("ZBD_API_KEY").unwrap();
     let zbdenv: String =
         env::var("ZBD_ENV").unwrap_or_else(|_| String::from("https://api.zebedee.io"));
-    let zebedee_client = ZebedeeClient::new().domain(zbdenv).apikey(apikey).build();
+    let zebedee_client = ZebedeeClient::new(apikey).domain(zbdenv);
 
     let user_id = String::from("0a872b22-d3e2-46c8-84af-139cce32a4c5");
 

--- a/src/internal_transfer/tests.rs
+++ b/src/internal_transfer/tests.rs
@@ -7,7 +7,7 @@ async fn test_internal_transfer() {
     let apikey: String = env::var("ZBD_API_KEY").unwrap();
     let zbdenv: String =
         env::var("ZBD_ENV").unwrap_or_else(|_| String::from("https://api.zebedee.io"));
-    let zebedee_client = ZebedeeClient::new().domain(zbdenv).apikey(apikey).build();
+    let zebedee_client = ZebedeeClient::new(apikey).domain(zbdenv);
 
     let internal_transfer_payload = InternalTransfer {
         amount: String::from("10000"),

--- a/src/keysend/tests.rs
+++ b/src/keysend/tests.rs
@@ -7,7 +7,7 @@ async fn test_keysend() {
     let apikey: String = env::var("ZBD_API_KEY").unwrap();
     let zbdenv: String =
         env::var("ZBD_ENV").unwrap_or_else(|_| String::from("https://api.zebedee.io"));
-    let zebedee_client = ZebedeeClient::new().domain(zbdenv).apikey(apikey).build();
+    let zebedee_client = ZebedeeClient::new(apikey).domain(zbdenv);
 
     let keysend_payload = Keysend {
         amount: String::from("1000"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -546,17 +546,6 @@ impl ZebedeeOauth {
     }
 }
 
-impl Default for ZebedeeClient {
-    fn default() -> Self {
-        ZebedeeClient {
-            domain: String::from("https://api.zebedee.io"),
-            reqw_cli: reqwest::Client::new(),
-            apikey: String::from("errornotset"),
-            oauth: Default::default(),
-        }
-    }
-}
-
 #[derive(Clone, Debug, Validate, Deserialize)]
 pub struct PKCE {
     #[validate(length(equal = 43))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@ pub mod voucher;
 pub mod wallet;
 pub mod withdrawal_request;
 
+use std::borrow::Cow;
+
 use charges::*;
 use email::*;
 use errors::*;
@@ -45,28 +47,25 @@ pub struct ZebedeeClient {
 }
 
 impl ZebedeeClient {
-    pub fn new() -> Self {
-        ZebedeeClient::default()
+    pub fn new<'a>(apikey: impl Into<Cow<'a, str>>) -> Self {
+        Self {
+            apikey: apikey.into().into_owned(),
+            domain: "https://api.zebedee.io".to_owned(),
+            reqw_cli: reqwest::Client::new(),
+            oauth: Default::default(),
+        }
     }
 
     /// Zebedee REST API url
-    pub fn domain(mut self, domain: String) -> Self {
-        self.domain = domain;
-        self
+    pub fn domain(self, domain: String) -> Self {
+        Self { domain, ..self }
     }
 
-    /// Project API key
-    pub fn apikey(mut self, apikey: String) -> Self {
-        self.apikey = apikey;
-        self
-    }
-
-    pub fn reqw_cli(mut self, reqw_cli: reqwest::Client) -> Self {
-        self.reqw_cli = reqw_cli;
-        self
+    pub fn reqw_cli(self, reqw_cli: reqwest::Client) -> Self {
+        Self { reqw_cli, ..self }
     }
     pub fn oauth(
-        mut self,
+        self,
         client_id: String,
         secret: String,
         redirect_uri: String,
@@ -74,17 +73,7 @@ impl ZebedeeClient {
         scope: String,
     ) -> Self {
         let oauth = ZebedeeOauth::new(client_id, secret, redirect_uri, state, scope);
-        self.oauth = oauth;
-        self
-    }
-
-    pub fn build(self) -> Self {
-        ZebedeeClient {
-            domain: self.domain,
-            reqw_cli: self.reqw_cli,
-            apikey: self.apikey,
-            oauth: self.oauth,
-        }
+        Self { oauth, ..self }
     }
 
     async fn parse_response<T>(&self, resp: Response) -> Result<T>

--- a/src/ln_address/tests.rs
+++ b/src/ln_address/tests.rs
@@ -8,7 +8,7 @@ async fn test_pay_ln_address() {
     let apikey: String = env::var("ZBD_API_KEY").unwrap();
     let zbdenv: String =
         env::var("ZBD_ENV").unwrap_or_else(|_| String::from("https://api.zebedee.io"));
-    let zebedee_client = ZebedeeClient::new().domain(zbdenv).apikey(apikey).build();
+    let zebedee_client = ZebedeeClient::new(apikey).domain(zbdenv);
     let block = 69420;
     let payment = &LnPayment {
         ln_address: String::from("miketwenty1@zbd.gg"),
@@ -27,7 +27,7 @@ async fn test_fetch_charge_ln_address() {
     let apikey: String = env::var("ZBD_API_KEY").unwrap();
     let zbdenv: String =
         env::var("ZBD_ENV").unwrap_or_else(|_| String::from("https://api.zebedee.io"));
-    let zebedee_client = ZebedeeClient::new().domain(zbdenv).apikey(apikey).build();
+    let zebedee_client = ZebedeeClient::new(apikey).domain(zbdenv);
 
     let payment = LnFetchCharge {
         ln_address: String::from("miketwenty1@zbd.gg"),
@@ -47,7 +47,7 @@ async fn test_validate_ln_address() {
     let apikey: String = env::var("ZBD_API_KEY").unwrap();
     let zbdenv: String =
         env::var("ZBD_ENV").unwrap_or_else(|_| String::from("https://api.zebedee.io"));
-    let zebedee_client = ZebedeeClient::new().domain(zbdenv).apikey(apikey).build();
+    let zebedee_client = ZebedeeClient::new(apikey).domain(zbdenv);
 
     let ln_address = String::from("andre@zbd.gg");
 

--- a/src/login_with_zbd/tests.rs
+++ b/src/login_with_zbd/tests.rs
@@ -29,17 +29,13 @@ async fn test_create_oauth_auth_url() {
     let zbdenv: String =
         env::var("ZBD_ENV").unwrap_or_else(|_| String::from("https://api.zebedee.io"));
 
-    let zebedee_client = ZebedeeClient::new()
-        .domain(zbdenv)
-        .apikey(apikey)
-        .oauth(
-            oauth_client_id,
-            oauth_secret,
-            redirect_uri,
-            state,
-            String::from("user"),
-        )
-        .build();
+    let zebedee_client = ZebedeeClient::new(apikey).domain(zbdenv).oauth(
+        oauth_client_id,
+        oauth_secret,
+        redirect_uri,
+        state,
+        "user".to_owned(),
+    );
 
     let c = PKCE::from("hellomynameiswhat");
     let r = zebedee_client.create_auth_url(&c.challenge);
@@ -57,17 +53,13 @@ async fn test_fetch_token() {
     let zbdenv: String =
         env::var("ZBD_ENV").unwrap_or_else(|_| String::from("https://api.zebedee.io"));
 
-    let zebedee_client = ZebedeeClient::new()
-        .domain(zbdenv)
-        .apikey(apikey)
-        .oauth(
-            oauth_client_id,
-            oauth_secret,
-            redirect_uri,
-            state,
-            String::from("user"),
-        )
-        .build();
+    let zebedee_client = ZebedeeClient::new(apikey).domain(zbdenv).oauth(
+        oauth_client_id,
+        oauth_secret,
+        redirect_uri,
+        state,
+        "user".to_owned(),
+    );
 
     let c = PKCE::from("hellomynameiswhat");
     let fake_code = "xxx11xx1-xxxx-xxxx-xxx1-1xx11xx111xx";
@@ -91,17 +83,13 @@ async fn test_refresh_token() {
     let zbdenv: String =
         env::var("ZBD_ENV").unwrap_or_else(|_| String::from("https://api.zebedee.io"));
 
-    let zebedee_client = ZebedeeClient::new()
-        .domain(zbdenv)
-        .apikey(apikey)
-        .oauth(
-            oauth_client_id,
-            oauth_secret,
-            redirect_uri,
-            state,
-            String::from("user"),
-        )
-        .build();
+    let zebedee_client = ZebedeeClient::new(apikey).domain(zbdenv).oauth(
+        oauth_client_id,
+        oauth_secret,
+        redirect_uri,
+        state,
+        "user".to_owned(),
+    );
 
     let fake_refresh_token = "xxx11xx1-xxxx-xxxx-xxx1-1xx11xx111xx";
     let r = zebedee_client.refresh_token(fake_refresh_token);
@@ -123,17 +111,13 @@ async fn test_fetch_user_data() {
     let zbdenv: String =
         env::var("ZBD_ENV").unwrap_or_else(|_| String::from("https://api.zebedee.io"));
 
-    let zebedee_client = ZebedeeClient::new()
-        .domain(zbdenv)
-        .apikey(apikey)
-        .oauth(
-            oauth_client_id,
-            oauth_secret,
-            redirect_uri,
-            state,
-            String::from("user"),
-        )
-        .build();
+    let zebedee_client = ZebedeeClient::new(apikey).domain(zbdenv).oauth(
+        oauth_client_id,
+        oauth_secret,
+        redirect_uri,
+        state,
+        "user".to_owned(),
+    );
 
     let fake_refresh_token = String::from("eyAAAAyomommagotocollegeAAAxxxXXAAAAasdfasdfsas");
     let r = zebedee_client.fetch_user_data(fake_refresh_token);
@@ -154,17 +138,13 @@ async fn test_fetch_user_wallet_data() {
     let zbdenv: String =
         env::var("ZBD_ENV").unwrap_or_else(|_| String::from("https://api.zebedee.io"));
 
-    let zebedee_client = ZebedeeClient::new()
-        .domain(zbdenv)
-        .apikey(apikey)
-        .oauth(
-            oauth_client_id,
-            oauth_secret,
-            redirect_uri,
-            state,
-            String::from("user,wallet"),
-        )
-        .build();
+    let zebedee_client = ZebedeeClient::new(apikey).domain(zbdenv).oauth(
+        oauth_client_id,
+        oauth_secret,
+        redirect_uri,
+        state,
+        "user,wallet".to_owned(),
+    );
 
     let fake_refresh_token = String::from("eyAAAAyomommagotocollegeAAAxxxXXAAAAasdfasdfsas");
     let r = zebedee_client.fetch_user_wallet_data(fake_refresh_token);

--- a/src/payments/tests.rs
+++ b/src/payments/tests.rs
@@ -7,7 +7,7 @@ async fn test_pay_invoice() {
     let apikey: String = env::var("ZBD_API_KEY").unwrap();
     let zbdenv: String =
         env::var("ZBD_ENV").unwrap_or_else(|_| String::from("https://api.zebedee.io"));
-    let zebedee_client = ZebedeeClient::new().domain(zbdenv).apikey(apikey).build();
+    let zebedee_client = ZebedeeClient::new(apikey).domain(zbdenv);
 
     let payment = Payment {
         invoice: String::from("lnbc120n1p0tdjwmpp5ycws0d788cjeqp9rn2wwxfymrekj9n80wy2yrk66tuu3ga5wukfsdzq2pshjmt9de6zqen0wgsrzv3qwp5hsetvwvsxzapqwdshgmmndp5hxtnsd3skxefwxqzjccqp2sp5vnsvmjlu6hrfegcdjs47njrga36g3x45wfmqjjjlerwgagj62yysrzjq2v4aw4gy7m93en32dcaplym056zezcljdjshyk8yakwtsp2h4yvcz9atuqqhtsqqqqqqqlgqqqqqqgqjq9qy9qsqhykfacrdy06cuyegvt4p50su53qwgrqn5jf6d83fd0upsa4frpxqnm2zl323zuvmz5ypv9gh9nr3jav6u2ccwkpd56h3n6l3ja5q7wgpxudlv4"),
@@ -23,7 +23,7 @@ async fn test_get_payments() {
     let apikey: String = env::var("ZBD_API_KEY").unwrap();
     let zbdenv: String =
         env::var("ZBD_ENV").unwrap_or_else(|_| String::from("https://api.zebedee.io"));
-    let zebedee_client = ZebedeeClient::new().domain(zbdenv).apikey(apikey).build();
+    let zebedee_client = ZebedeeClient::new(apikey).domain(zbdenv);
     let rrr = zebedee_client.get_payments().await;
     println!("{:#?}", rrr);
     let r = zebedee_client.get_payments().await.unwrap();
@@ -35,7 +35,7 @@ async fn test_get_payment() {
     let apikey: String = env::var("ZBD_API_KEY").unwrap();
     let zbdenv: String =
         env::var("ZBD_ENV").unwrap_or_else(|_| String::from("https://api.zebedee.io"));
-    let zebedee_client = ZebedeeClient::new().domain(zbdenv).apikey(apikey).build();
+    let zebedee_client = ZebedeeClient::new(apikey).domain(zbdenv);
 
     let payment_id = String::from("5d88b2e0-e491-40e1-a8a8-a81ae68f2297");
 

--- a/src/utilities/tests.rs
+++ b/src/utilities/tests.rs
@@ -6,7 +6,7 @@ async fn test_get_is_supported_region_by_ip() {
     let apikey: String = env::var("ZBD_API_KEY").unwrap();
     let zbdenv: String =
         env::var("ZBD_ENV").unwrap_or_else(|_| String::from("https://api.zebedee.io"));
-    let zebedee_client = ZebedeeClient::new().domain(zbdenv).apikey(apikey).build();
+    let zebedee_client = ZebedeeClient::new(apikey).domain(zbdenv);
 
     let ip = "3.225.112.64";
 
@@ -23,7 +23,7 @@ async fn test_get_prod_ips() {
     let apikey: String = env::var("ZBD_API_KEY").unwrap();
     let zbdenv: String =
         env::var("ZBD_ENV").unwrap_or_else(|_| String::from("https://api.zebedee.io"));
-    let zebedee_client = ZebedeeClient::new().domain(zbdenv).apikey(apikey).build();
+    let zebedee_client = ZebedeeClient::new(apikey).domain(zbdenv);
 
     let r = zebedee_client.get_prod_ips().await.unwrap().success;
     assert!(r);
@@ -34,7 +34,7 @@ async fn test_get_btc_usd() {
     let apikey: String = env::var("ZBD_API_KEY").unwrap();
     let zbdenv: String =
         env::var("ZBD_ENV").unwrap_or_else(|_| String::from("https://api.zebedee.io"));
-    let zebedee_client = ZebedeeClient::new().domain(zbdenv).apikey(apikey).build();
+    let zebedee_client = ZebedeeClient::new(apikey).domain(zbdenv);
     let r = zebedee_client.get_btc_usd().await.unwrap().success;
     assert!(r);
 }

--- a/src/wallet/tests.rs
+++ b/src/wallet/tests.rs
@@ -6,7 +6,7 @@ async fn test_wallet_details() {
     let apikey: String = env::var("ZBD_API_KEY").unwrap();
     let zbdenv: String =
         env::var("ZBD_ENV").unwrap_or_else(|_| String::from("https://api.zebedee.io"));
-    let zebedee_client = ZebedeeClient::new().domain(zbdenv).apikey(apikey).build();
+    let zebedee_client = ZebedeeClient::new(apikey).domain(zbdenv);
     let any_balance = 0..; //u64::MAX;
     let r = zebedee_client
         .get_wallet_details()

--- a/src/withdrawal_request/tests.rs
+++ b/src/withdrawal_request/tests.rs
@@ -7,7 +7,7 @@ async fn test_create_withdrawal_request() {
     let apikey: String = env::var("ZBD_API_KEY").unwrap();
     let zbdenv: String =
         env::var("ZBD_ENV").unwrap_or_else(|_| String::from("https://api.zebedee.io"));
-    let zebedee_client = ZebedeeClient::new().domain(zbdenv).apikey(apikey).build();
+    let zebedee_client = ZebedeeClient::new(apikey).domain(zbdenv);
 
     let withdrawal_request = WithdrawalReqest {
         amount: String::from("10000"),
@@ -25,7 +25,7 @@ async fn test_get_withdrawal_requests() {
     let apikey: String = env::var("ZBD_API_KEY").unwrap();
     let zbdenv: String =
         env::var("ZBD_ENV").unwrap_or_else(|_| String::from("https://api.zebedee.io"));
-    let zebedee_client = ZebedeeClient::new().domain(zbdenv).apikey(apikey).build();
+    let zebedee_client = ZebedeeClient::new(apikey).domain(zbdenv);
 
     let r = zebedee_client.get_withdrawal_requests().await.unwrap();
     assert!(r.success);
@@ -35,7 +35,7 @@ async fn test_get_withdrawal_request() {
     let apikey: String = env::var("ZBD_API_KEY").unwrap();
     let zbdenv: String =
         env::var("ZBD_ENV").unwrap_or_else(|_| String::from("https://api.zebedee.io"));
-    let zebedee_client = ZebedeeClient::new().domain(zbdenv).apikey(apikey).build();
+    let zebedee_client = ZebedeeClient::new(apikey).domain(zbdenv);
 
     let withdrawal_request = WithdrawalReqest {
         amount: String::from("10000"),


### PR DESCRIPTION
refactor `ZebedeeClient` to be more in line with the actual builder pattern used in Rust. 
- the `build()` used previously didn't do anything, just copied from modified struct to the final one which is not the best approach
- `ZebedeeCliend::default()` is not correct from user perspective as without an api key you should not be able to use the client