### PR TITLE
fix empty message on api return error

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -26,7 +26,7 @@ pub enum ZebedeeError {
 #[serde(default)]
 pub struct ApiError {
     /// Error message
-    pub message: String,
+    pub message: Option<String>,
     /// Status of API call
     pub success: bool,
 }
@@ -59,6 +59,9 @@ impl From<ApiError> for ZebedeeError {
 
 impl Display for ApiError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.message.as_str())
+        match &self.message {
+            Some(s) => f.write_str(s.as_str()),
+            None => f.write_str("No Message Returned"),
+        }
     }
 }

--- a/src/login_with_zbd/tests.rs
+++ b/src/login_with_zbd/tests.rs
@@ -168,9 +168,11 @@ async fn test_fetch_user_wallet_data() {
 
     let fake_refresh_token = String::from("eyAAAAyomommagotocollegeAAAxxxXXAAAAasdfasdfsas");
     let r = zebedee_client.fetch_user_wallet_data(fake_refresh_token);
+
     let i = match r.await {
         Err(e) => e.to_string(),
         Ok(_) => "was a good token but it shouldnt be".to_string(),
     };
-    assert!(i.is_empty());
+
+    assert!(i.contains("No Message Returned"));
 }


### PR DESCRIPTION
When the `test_fetch_user_wallet_data` test runs, the zbd api does not return a `message` for the `Api_Error`. This change adds a `"No Message Returned"` error message when there is no message 